### PR TITLE
embed default corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,7 +149,9 @@ dependencies = [
  "clap",
  "glob",
  "log",
+ "postcard",
  "rand",
+ "serde",
  "simple_logger",
  "tablestream",
 ]
@@ -178,6 +189,18 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "errno"
@@ -306,6 +329,18 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -493,6 +528,26 @@ dependencies = [
  "crossterm",
  "unicode-truncate",
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,18 @@ anyhow = "1.0.71"
 clap = "~4.4"
 glob = "0.3.1"
 log = "0.4.19"
+postcard = { version = "1.0.4", features = ["use-std"], default-features = false }
+serde = { version = "1.0.164", features = ["derive"] }
 simple_logger = "4.1.0"
 tablestream = "0.1.3"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 rand = "0.8.5"
+
+[build-dependencies]
+anyhow = "1.0.71"
+glob = "0.3.1"
+log = "0.4.19"
+postcard = { version = "1.0.4", features = ["use-std"], default-features = false }
+serde = { version = "1.0.164", features = ["derive"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+#[allow(dead_code)]
+mod corpus {
+    include!("src/corpus.rs");
+}
+
+fn main() {
+    // load default corpus
+    let default = corpus::load_corpus("cpu_rec_corpus/*.corpus").unwrap();
+    println!("cargo:rerun-if-changed=cpu_rec_corpus");
+
+    // serialize to bytes
+    let bytes = postcard::to_stdvec(&default).unwrap();
+
+    // output path to target build folder
+    let mut outfile = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    outfile.push("default.pc");
+
+    // write to file
+    std::fs::write(outfile, bytes).unwrap();
+}

--- a/src/corpus.rs
+++ b/src/corpus.rs
@@ -16,12 +16,13 @@
 use anyhow::{Context, Error, Ok, Result};
 use glob::glob;
 use log::debug;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::string::String;
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CorpusStats {
     pub arch: String,
     bigrams_freq: HashMap<(u8, u8), f32>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,38 +225,26 @@ fn main() -> Result<()> {
 
     let corpus_dir_res = args.get_one::<String>("corpus");
 
-    /* Use the given path to load the corpus from, else try
-     * to find it in the current directory or in the exec
-     * folder */
-    let corpus_dir = match corpus_dir_res {
-        Some(c) => c.to_owned(),
-        None => if Path::new("cpu_rec_corpus").is_dir() {
-            "cpu_rec_corpus".to_string()
-        } else {
-            let exe_path = std::env::current_exe().with_context(|| "Could not get exe filename")?;
-            let parent_path = exe_path.parent().unwrap();
-            if parent_path.join("cpu_rec_corpus").is_dir() {
-                // Found it in the exe path
-                parent_path
-                    .join("cpu_rec_corpus")
-                    .to_str()
-                    .unwrap()
-                    .to_string()
-            } else {
-                bail!("Could not find \"cpu_rec_corpus\", please specify it using --corpus");
+    // Use the given path to load the corpus from, else use the embedded corpus
+    let corpus_stats = match corpus_dir_res {
+        Some(c) => {
+            if !Path::new(&c).is_dir() {
+                bail!("{c} is not a valid directory");
             }
+
+            let corpus_files = Path::new(&c).join("*.corpus");
+            println!("Loading corpus from {:?}", corpus_files);
+
+            load_corpus(&corpus_files.to_str().unwrap())?
         }
-        .to_owned(),
+        None => {
+            println!("Loading embedded corpus");
+            // serialized bytes embedded from build.rs
+            let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/default.pc"));
+            // deserialize
+            postcard::from_bytes(bytes).unwrap()
+        }
     };
-
-    if !Path::new(&corpus_dir).is_dir() {
-        bail!("{} is not a valid directory", corpus_dir);
-    }
-
-    let corpus_files = Path::new(&corpus_dir).join("*.corpus");
-    println!("Loading corpus from {:?}", corpus_files);
-
-    let corpus_stats = load_corpus(&corpus_files.to_str().unwrap())?;
 
     info!("Corpus size: {}", corpus_stats.len());
 


### PR DESCRIPTION
hey thanks for this tool, it came in handy identifying 8051 firmware today!

when in doubt, it's always 8051 ;)

anyway, I hit a small snag when trying to just `cargo install --git https://github.com/trou/cpu_rec_rs` and go (because the corpus wasn't on my local disk). Not too big of a deal, but a self-contained binary would be more convenient than keeping a copy of the corpus files around.

This obviously bloats the binary size. I chose postcard to encode the corpus, which is relatively compact, but the corpus still weighs in around 40MB.

So then I compressed it with lz4 and landed around 32MB for the executable (apple m1 mach-o binary).

In my opinion that's a good tradeoff, what do you think?