### PR TITLE
Proposed fix for rust 1.68

### DIFF
--- a/src/corpus.rs
+++ b/src/corpus.rs
@@ -50,11 +50,13 @@ pub fn load_corpus(path: &str) -> Result<Vec<CorpusStats>, Error> {
             Ok(CorpusStats::new(arch_name, &data, 0.01))
         })
         .collect();
-    if res.as_ref().is_ok_and(|res_v| res_v.len() == 0) {
-        Err(Error::msg("Could not find any file in corpus directory"))
-    } else {
-        res
+    if let Result::Ok(res_v) = &res {
+        if res_v.is_empty() {
+            return Err(Error::msg("Could not find any file in corpus directory"));
+        }
     }
+    res
+        
 }
 
 // Convenience struct for readability

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,12 @@ fn guess_with_windows(
             // Should we add the previous guess to the result ?  yes if it's
             // either unknown (None) or different from the new one
             let do_push = match &win_res {
-                Some(wres) => !cur_guess.arch.as_ref().is_some_and(|a| a == wres),
+                Some(wres) => {
+                    match cur_guess.arch.as_ref() {
+                        Some(a) => a != wres,
+                        None => true,
+                    }
+                },
                 _ => true,
             };
             if do_push {


### PR DESCRIPTION
Proposed fix for running on rust 1.68, avoid the use of : 
- is_ok_and()
- is_some_and()